### PR TITLE
Followup of https://github.com/iotappstory/ESP-Library/pull/30

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,24 @@ setup () {
 ```
 </br>
 
+### `loop()`
+This function ensures the library performs all the periodic tasks it needs to performm:
+
+* [`buttonLoop()`](#buttonLoop())
+* [`callHome()`](#callHome()): This will be called if you have previously called [`setCallHome(true)`](#setCallHome(bool)) and if the timer set by [`setCallHomeInterval()`](#setCallHomeInterval(int)) (default = 7200 seconds or 2 hours) has expired.
+
+It is essential that this function called on the first line of your main sketch's `loop()`.
+
 ### `buttonLoop()`
-Checks if the button is depressed and what mode to enter when once it is released. This is essential and needs to be called on the first line of your `loop()`.</br></br>
+Checks if the button is depressed and what mode to enter when once it is released. Also returns the buttonstate in `ModeButtonState` format:
+```
+ModeButtonNoPress,        // mode button is not pressed
+ModeButtonShortPress,     // short press - will enter in firmwareupdate mode
+ModeButtonLongPress,      // long press - will enter in configurationmode
+ModeButtonVeryLongPress,  // very long press - won't do anything (but the app developer might want to do something)
+ModeButtonFirmwareUpdate, // about to enter in firmware update mode
+ModeButtonConfigMode      // about to enter in configuration mode
+```
 
 ### `callHome(bool spiffs)`
 Calls IOTAppStory.com to check for updates. The `setCallHomeInterval()` function mentioned above already handles calling home at a certain interval. But if you would like to decide yourself under which circumstances and when to call home. This is for you.
@@ -225,7 +241,7 @@ If `spiffs` is true, the call also checks if there is a new filesystem image to 
 ...
 
 void loop() {
-    IAS.buttonLoop();
+    IAS.loop();
     
     if(batLvl >= 20 && lstUpd != today){
         IAS.callHome();

--- a/examples/IASBlink/IASBlink.ino
+++ b/examples/IASBlink/IASBlink.ino
@@ -86,7 +86,7 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.buttonLoop();																	        // this routine handles the reaction of the Flash button. If short press: update of skethc, long press: Configuration
+  IAS.loop();																// this routine handles the calling home on the configured itnerval as well as reaction of the Flash button. If short press: update of skethc, long press: Configuration
 
 
   //-------- Your Sketch starts from here ---------------

--- a/examples/IASLoader/IASLoader.ino
+++ b/examples/IASLoader/IASLoader.ino
@@ -85,5 +85,5 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.buttonLoop();                       // this routine handles the reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
+  IAS.loop();                             // this routine handles the calling home on the configured itnerval as well as reaction of the Flash button. If short press: update of skethc, long press: Configuration
 }

--- a/examples/VirginSoil-Basic/VirginSoil-Basic.ino
+++ b/examples/VirginSoil-Basic/VirginSoil-Basic.ino
@@ -47,7 +47,7 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.buttonLoop();				// this routine handles the reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
+  IAS.loop();				// this routine handles the reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
 
   //-------- Your Sketch starts from here ---------------
 

--- a/examples/VirginSoil-Full/VirginSoil-Full.ino
+++ b/examples/VirginSoil-Full/VirginSoil-Full.ino
@@ -147,7 +147,7 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.buttonLoop();                                   // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
+  IAS.loop();                                   // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
 
 
   //-------- Your Sketch starts from here ---------------

--- a/examples/VirginSoil-NeoPixel-Callbacks/VirginSoil-NeoPixel-Callbacks.ino
+++ b/examples/VirginSoil-NeoPixel-Callbacks/VirginSoil-NeoPixel-Callbacks.ino
@@ -140,7 +140,7 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.buttonLoop();                                        // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
+  IAS.loop();                                        // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
 
 
   //-------- Your Sketch starts from here ---------------

--- a/examples/WebAppToggleBtn/WebAppToggleBtn.ino
+++ b/examples/WebAppToggleBtn/WebAppToggleBtn.ino
@@ -179,7 +179,7 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.buttonLoop(); // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
+  IAS.loop(); // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
 
 
   //-------- Your Sketch starts from here ---------------

--- a/examples/Wemos/Wemos-IASLoader/Wemos-IASLoader.ino
+++ b/examples/Wemos/Wemos-IASLoader/Wemos-IASLoader.ino
@@ -118,7 +118,7 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.buttonLoop();                                         // this routine handles the reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
+  IAS.loop();                                         // this routine handles the reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
 
 
   if (millis() - printEntry > 5000 && digitalRead(D3) == HIGH) {

--- a/examples/Wemos/Wemos-Shield-Clock/Wemos-Shield-Clock.ino
+++ b/examples/Wemos/Wemos-Shield-Clock/Wemos-Shield-Clock.ino
@@ -145,7 +145,7 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.buttonLoop();   // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
+  IAS.loop();   // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
 
 
   //-------- Your Sketch starts from here ---------------

--- a/examples/Wemos/Wemos-Shield-DHT/Wemos-Shield-DHT.ino
+++ b/examples/Wemos/Wemos-Shield-DHT/Wemos-Shield-DHT.ino
@@ -176,7 +176,7 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.buttonLoop();   // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
+  IAS.loop();   // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
 
 
   //-------- Your Sketch starts from here ---------------

--- a/examples/Wemos/Wemos-VirginSoil-OLED-Callbacks/Wemos-VirginSoil-OLED-Callbacks.ino
+++ b/examples/Wemos/Wemos-VirginSoil-OLED-Callbacks/Wemos-VirginSoil-OLED-Callbacks.ino
@@ -106,7 +106,7 @@ void setup() {
 
 // ================================================ LOOP =================================================
 void loop() {
-  IAS.buttonLoop();   // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
+  IAS.loop();   // this routine handles the calling home functionality and reaction of the MODEBUTTON pin. If short press (<4 sec): update of sketch, long press (>7 sec): Configuration
 
 
   //-------- Your Sketch starts from here ---------------

--- a/keywords.txt
+++ b/keywords.txt
@@ -37,6 +37,7 @@ onConfigMode	KEYWORD2
 addField	KEYWORD2
 begin	KEYWORD2
 buttonLoop	KEYWORD2
+loop	KEYWORD2
 callHome	KEYWORD2
 setCallHome	KEYWORD2
 setCallHomeInterval	KEYWORD2

--- a/src/IOTAppStory.cpp
+++ b/src/IOTAppStory.cpp
@@ -1199,16 +1199,17 @@ void IOTAppStory::readConfig() {
 }
 
 
-void IOTAppStory::updateLoop() {
+void IOTAppStory::loop() {
    if (_callHome && millis() - _lastCallHomeTime > _callHomeInterval) {
       this->callHome();
       _lastCallHomeTime = millis();
    }
+
+   this->buttonLoop();
 }
 
 
 ModeButtonState IOTAppStory::buttonLoop() {
-   this->updateLoop();
    return getModeButtonState();
 }
 

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -232,11 +232,12 @@
 						//void preSetServer(String HOST1, String FILE1);
             
 						void setCallHome(bool callHome);
-            void setCallHomeInterval(unsigned long interval);
+                  void setCallHomeInterval(unsigned long interval);
 						
 						void begin(char ea);
 						
-            ModeButtonState buttonLoop();
+                  void loop();
+                  ModeButtonState buttonLoop();
 
 						void writeConfig(bool wifiSave = false);
 						void readConfig();


### PR DESCRIPTION
Re-implemented changes which we removed out of #30 in order to not introduce breaking changes. Since we are now making a new major release this is the right time to introduce such changes:

I've created a general `IOTAppStory::loop()` function for the library which will do 2 things:
- call `buttonLoop()` function every time (so this is not necessary in the main sketch anymore)
- perform call home functionality if it is enabled, and at the correct interval that was configured.

The `IOTAppStory::loop()` function should be called in the main sketch's `loop()`.

I've also modified all examples to represent these changes.
README.md has been updated as well

**NOTE:**Because of https://github.com/iotappstory/ESP-Library/issues/66, I was not able to test my changes completely