### PR TITLE
Develop

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -36,7 +36,6 @@ onConfigMode	KEYWORD2
 
 addField	KEYWORD2
 begin	KEYWORD2
-buttonLoop	KEYWORD2
 loop	KEYWORD2
 callHome	KEYWORD2
 setCallHome	KEYWORD2

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -241,8 +241,8 @@
 						
 						void begin(char ea);
 						
-                  void loop();
-                  ModeButtonState buttonLoop();
+            void loop();
+                  
 
 						void writeConfig(bool wifiSave = false);
 						void readConfig();
@@ -382,7 +382,7 @@
             void updateLoop();
             bool isModeButtonPressed();
             ModeButtonState getModeButtonState();
-    
+						ModeButtonState buttonLoop();
 
 						
 						


### PR DESCRIPTION
- Changed the ModeButtonState buttonLoop() to private. Mainly to generate an error forcing users to update buttonloop() to loop() in their old sketches.
- removed redundant keyword from the list