### PR TITLE
FNGPRINT & SPIFFS fixes

### DIFF
--- a/src/IOTAppStory.cpp
+++ b/src/IOTAppStory.cpp
@@ -1392,7 +1392,7 @@ String IOTAppStory::servHdlDevInfo(){
 	retHtml.replace(F("{cid}"), String(ESP_GETCHIPID));
 	retHtml.replace(F("{fid}"), String(ESP_GETFLASHCHIPID));
 
-	#if HTTPS_8266_TYPE == FNGPRINT
+	#if defined  ESP8266 && HTTPS_8266_TYPE == FNGPRINT
 		retHtml.replace(F("{f}"), config.sha1);
 	#endif
 
@@ -1647,7 +1647,7 @@ String IOTAppStory::strCertScan(String path){
 	#endif
 	
 	//Initialize File System
-	if(!SPIFFS.begin()){
+	if(!ESP_SPIFFSBEGIN){
 		#if DEBUG_LVL >= 3
 			DEBUG_PRINT(F(" SPIFFS Mount Failed"));
 		#endif

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -61,7 +61,7 @@
 		
 		char deviceName[STRUCT_BNAME_SIZE];
 		char compDate[STRUCT_COMPDATE_SIZE];     // saved compile date time
-		#if HTTPS_8266_TYPE == FNGPRINT
+		#if defined  ESP8266 && HTTPS_8266_TYPE == FNGPRINT
 			char sha1[60];
 		#endif
 		#if CFG_AUTHENTICATE == true
@@ -118,7 +118,7 @@
 
 	const char HTTP_APP_INFO[] PROGMEM    = "{\"l\":\"{l}\", \"v\":\"{v}\", \"n\":\"{n}\", \"m\":\"{m}\", \"t\":\"{t}\"}";
 
-	#if HTTPS_8266_TYPE == FNGPRINT
+	#if defined  ESP8266 && HTTPS_8266_TYPE == FNGPRINT
 		const char HTTP_DEV_INFO[] PROGMEM = "{\"s1\":\"{s1}\", \"s2\":\"{s2}\", \"s3\":\"{s3}\", \"cid\":\"{cid}\", \"fid\":\"{fid}\", \"fss\":\"{fss}\", \"ss\":\"{ss}\", \"fs\":\"{fs}\", \"ab\":\"{ab}\", \"ac\":\"{ac}\", \"mc\":\"{mc}\", \"xf\":\"{xf}\", \"f\":\"{f}\"}";
 	#else
 		const char HTTP_DEV_INFO[] PROGMEM = "{\"s1\":\"{s1}\", \"s2\":\"{s2}\", \"s3\":\"{s3}\", \"cid\":\"{cid}\", \"fid\":\"{fid}\", \"fss\":\"{fss}\", \"ss\":\"{ss}\", \"fs\":\"{fs}\", \"ab\":\"{ab}\", \"ac\":\"{ac}\", \"mc\":\"{mc}\", \"xf\":\"{xf}\"}";
@@ -146,7 +146,7 @@
 			{"","",""},
 			"yourESP",
 			"",
-			#if HTTPS_8266_TYPE == FNGPRINT
+			#if defined  ESP8266 && HTTPS_8266_TYPE == FNGPRINT
 				HTTPS_FNGPRINT,
 			#endif
 			#if CFG_AUTHENTICATE == true

--- a/src/config.h
+++ b/src/config.h
@@ -119,11 +119,13 @@
 	#define MAGICEEP      				"%"
 	
 	
-	// define for get chip id
+	
 	#if defined  ESP8266
-		#define ESP_GETCHIPID ESP.getChipId()
-		#define ESP_GETFLASHCHIPID ESP.getFlashChipId()
+		#define ESP_GETCHIPID ESP.getChipId()				// define for get chip id
+		#define ESP_GETFLASHCHIPID ESP.getFlashChipId()		// define for get flash chip id
+		#define ESP_SPIFFSBEGIN SPIFFS.begin()				// define for SPIFFS.begin()
 	#elif defined ESP32
 		#define ESP_GETCHIPID (uint32_t)ESP.getEfuseMac()
 		#define ESP_GETFLASHCHIPID (uint32_t)g_rom_flashchip.device_id
+		#define ESP_SPIFFSBEGIN SPIFFS.begin(true)
 	#endif

--- a/src/espressif/configServer.cpp
+++ b/src/espressif/configServer.cpp
@@ -14,7 +14,7 @@ void configServer::run(){
 		bool exitConfig = false;
 		
 		#if CFG_STORAGE == ST_SPIFFS || CFG_STORAGE == ST_HYBRID
-			if(!SPIFFS.begin()){
+			if(!ESP_SPIFFSBEGIN){
 				#if DEBUG_LVL >= 1
 					DEBUG_PRINT(F(" SPIFFS Mount Failed"));
 				#endif

--- a/src/espressif/esp32/callServer_WiFiClientSecure.cpp
+++ b/src/espressif/esp32/callServer_WiFiClientSecure.cpp
@@ -114,7 +114,7 @@
 				#endif
 				
 				// Start SPIFFS and load partition
-				if(!SPIFFS.begin()){
+				if(!ESP_SPIFFSBEGIN){
 				   (*_statusMessage) = SER_SPIFFS_PART_NOT_FOUND;
 				   return false;
 				} 


### PR DESCRIPTION
**FNGPRINT**
Fix ESP32 errors caused by my previous PR #118 (Reenabled fingerprint for backwards compatibility)
#if HTTPS_8266_TYPE == FNGPRINT
should have been: #if defined  ESP8266 && HTTPS_8266_TYPE == FNGPRINT

**SPIFFS**
- On the ESP8266 SPIFFS just works whether their was a previous partition or not.
- On the ESP32 it is necessary to format SPIFFS the first time you run. Otherwise SPIFFS cannot be used to store certificates.
E (4881) SPIFFS: mount failed, -10025