### PR TITLE
free heap, new EEPROM layout, multiple small fixes & updated examples

### DIFF
--- a/examples/LOLIN(WEMOS) D1 mini/Wemos-IASLoader/Wemos-IASLoader.ino
+++ b/examples/LOLIN(WEMOS) D1 mini/Wemos-IASLoader/Wemos-IASLoader.ino
@@ -1,6 +1,6 @@
 /*
-	This is an initial sketch to get your device registered at IOTappstory.com
-	You will need an account at IOTAppStory.com 
+  This is an initial sketch to get your device registered at IOTappstory.com
+  You will need an account at IOTAppStory.com 
 
   You will need the button & OLED shields!
 

--- a/examples/LOLIN(WEMOS) D1 mini/Wemos-VirginSoil-OLED-Callbacks/Wemos-VirginSoil-OLED-Callbacks.ino
+++ b/examples/LOLIN(WEMOS) D1 mini/Wemos-VirginSoil-OLED-Callbacks/Wemos-VirginSoil-OLED-Callbacks.ino
@@ -43,6 +43,8 @@ IOTAppStory IAS(COMPDATE, MODEBUTTON);                    // Initialize IotAppSt
 
 // ================================================ VARS =================================================
 unsigned long printEntry;
+String deviceName = "woled-vs";
+String chipId;
 
 
 
@@ -56,8 +58,12 @@ void setup() {
   display.drawString(48, 35, F("Wait"));
   display.display();
 
-
-  IAS.preSetDeviceName("wemos-oled-virginsoil");          // preset deviceName this is also your MDNS responder: http://woled-vs.local
+  // create a unique deviceName for classroom situations (deviceName-123)
+  chipId      = String(ESP_GETCHIPID);
+  chipId      = "-"+chipId.substring(chipId.length()-3);
+  deviceName += chipId;
+  
+  IAS.preSetDeviceName(deviceName);                       // preset deviceName this is also your MDNS responder: http://woled-vs.local
   
 
 

--- a/examples/VirginSoil-Full/VirginSoil-Full.ino
+++ b/examples/VirginSoil-Full/VirginSoil-Full.ino
@@ -37,6 +37,8 @@ IOTAppStory IAS(COMPDATE, MODEBUTTON);                      // Initialize IotApp
 // ================================================ EXAMPLE VARS =========================================
 // used in this example to print variables every 10 seconds
 unsigned long printEntry;
+String deviceName = "virginsoil";
+String chipId;
 
 // We want to be able to edit these example variables below from the wifi config manager
 // Currently only char arrays are supported.
@@ -58,8 +60,13 @@ char* timeZone    = "0.0";
 
 // ================================================ SETUP ================================================
 void setup() {
+  // create a unique deviceName for classroom situations (deviceName-123)
+  chipId      = String(ESP_GETCHIPID);
+  chipId      = "-"+chipId.substring(chipId.length()-3);
+  deviceName += chipId;
+	
   /* TIP! delete lines below when not used */
-  IAS.preSetDeviceName("virginsoil");                       // preset deviceName this is also your MDNS responder: http://virginsoil.local
+  IAS.preSetDeviceName(deviceName);                       	// preset deviceName this is also your MDNS responder: http://virginsoil.local
   //IAS.preSetAutoUpdate(false);                            // automaticUpdate (true, false)
   //IAS.preSetAutoConfig(false);                            // automaticConfig (true, false)
   //IAS.preSetWifi("ssid","password");                      // preset Wifi

--- a/examples/WebAppToggleBtn/WebAppToggleBtn.ino
+++ b/examples/WebAppToggleBtn/WebAppToggleBtn.ino
@@ -1,34 +1,34 @@
 /* 
-	This is an initial sketch to be used as a "blueprint" to create apps which can be used with IOTAppStory.com infrastructure
-	Your code can be filled wherever it is marked.
+  This is an initial sketch to be used as a "blueprint" to create apps which can be used with IOTAppStory.com infrastructure
+  Your code can be filled wherever it is marked.
 
-	This sketch is based on:
-	VirginSoil sketch [Andreas Spiess]
-	FSWebServer - Example WebServer with SPIFFS backend for esp8266 [Hristo Gochkov]
-	Arduino Debounce [David A. Mellis]
+  This sketch is based on:
+  VirginSoil sketch [Andreas Spiess]
+  FSWebServer - Example WebServer with SPIFFS backend for esp8266 [Hristo Gochkov]
+  Arduino Debounce [David A. Mellis]
 
-	Copyright (c) [2017] [Onno Dirkzwager]
+  Copyright (c) [2017] [Onno Dirkzwager]
 
-	Permission is hereby granted, free of charge, to any person obtaining a copy
-	of this software and associated documentation files (the "Software"), to deal
-	in the Software without restriction, including without limitation the rights
-	to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-	copies of the Software, and to permit persons to whom the Software is
-	furnished to do so, subject to the following conditions:
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
 
-	The above copyright notice and this permission notice shall be included in all
-	copies or substantial portions of the Software.
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
 
-	THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-	IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-	FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-	AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-	LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-	OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-	SOFTWARE.
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.
 
-	Don't forget to upload the contents of the data folder with MkSPIFFS Tool ("ESP8266 Sketch Data Upload" in Tools menu in Arduino IDE)
-	or you can upload it to IOTAppStory.com
+  Don't forget to upload the contents of the data folder with MkSPIFFS Tool ("ESP8266 Sketch Data Upload" in Tools menu in Arduino IDE)
+  or you can upload it to IOTAppStory.com
 
   WebAppToggleBtn V3.0.1
 */

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -45,32 +45,32 @@
 		------ ------ ------ ------ ------ ------ STRUCTURES ------ ------ ------ ------ ------ ------
 	**/
 	
-	typedef struct eFields{
+	struct addFieldStruct{
 		const char* fieldLabel;
-		char* (*varPointer);
 		int length;
 		char type;
+		
+		const char magicBytes[2] = "%";
 	};
 
-	typedef struct strConfig{
-		char actCode[7];                         // saved IotAppStory activation code
-		char appName[33];
-		char appVersion[12];
-		char ssid[3][STRUCT_CHAR_ARRAY_SIZE];    // 3x SSID
-		char password[3][STRUCT_PASSWORD_SIZE];  // 3x PASS
+	struct configStruct{
+		char actCode[7] = "";							// saved IotAppStory activation code
+		char appName[33] = "";
+		char appVersion[12] = "";
+		char deviceName[STRUCT_BNAME_SIZE] = "yourESP";
+		char compDate[STRUCT_COMPDATE_SIZE];			// saved compile date time
 		
-		char deviceName[STRUCT_BNAME_SIZE];
-		char compDate[STRUCT_COMPDATE_SIZE];     // saved compile date time
 		#if defined  ESP8266 && HTTPS_8266_TYPE == FNGPRINT
-			char sha1[60];
+			char sha1[60] = HTTPS_FNGPRINT;
 		#endif
 		#if CFG_AUTHENTICATE == true
-			char cfg_pass[17];
+			char cfg_pass[17] = CFG_PASS;
 		#endif
-		#if NEXT_OTA == true
-			char next_md5[33];
+		#if OTA_UPD_CHECK_NEXTION == true
+			char next_md5[33] = "00000000000000000000000000000000";
 		#endif
-		const char magicBytes[4];
+		
+		char magicBytes[4] = MAGICBYTES;
 	};
 	
 	struct firmwareStruct{
@@ -101,9 +101,11 @@
 	/**
 		------ ------ ------ ------ ------ ------ PROGMEM ------ ------ ------ ------ ------ ------
 	*/
-
-	const char SER_DEV[] PROGMEM          = "*-------------------------------------------------------------------------*";
-	
+	#if DEBUG_LVL == 1
+		const char SER_DEV[] PROGMEM      = "---";
+	#else
+		const char SER_DEV[] PROGMEM      = "*-------------------------------------------------------------------------*";
+	#endif
 	const char HTTP_200[] PROGMEM         = "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n\r\n";
 	const char HTTP_TEMP_START[] PROGMEM  = "<!DOCTYPE html><html lang=\"en\"><head><meta charset=\"UTF-8\" name=\"viewport\" content=\"width=device-width, initial-scale=1, user-scalable=no\"/><meta name=\"theme-color\" content=\"#000\" />{h}<title>Config</title></head><body>";
 	const char HTTP_TEMP_END[] PROGMEM    = "</body></html>";
@@ -114,14 +116,19 @@
 	const char HTTP_AP_CSS[] PROGMEM      = "<style>#po,body,html{height:100%;width:100%}#m,.fi{opacity:0}#m,#m a{color:#000}#cnt,body{position:relative}#po,body,html,input{width:100%}body,body a,input{color:#FFF}.btn,body a:hover{text-decoration:none}@keyframes kfi{to{z-index:10;opacity:1}}.fi{z-index:10;animation:kfi .5s ease-in 1 forwards}body,html{padding:0;margin:0;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}*,:after,:before{-webkit-box-sizing:inherit;-moz-box-sizing:inherit;box-sizing:inherit}body{background:#000;font:14px sans-serif}#po{padding-top:100px;position:fixed;z-index:0;background:rgba(0,0,0,.8);text-align:center;opacity:1}#m{width:200px;padding:10px;display:inline-block;background:#FFF;text-align:left}#cnt{min-width:280px;max-width:425px;margin:0 auto;padding:0 15px;z-index:2;border:1px solid #000}input{padding:4px 8px;margin:4px 0 10px;background:0;outline:0;border:1px solid #ccc}input:focus{border-color:#fcbc12}.btn{width:50%;margin:10px 0 0;padding:5px 14px 8px;display:block;float:right;background:#fcbc12;border-radius:4px;border:0;font-size:16px;color:#fff;text-align:center}.btn.sm{font-size:15px;padding:3px 14px 4px}.btn:active,.btn:focus,.btn:hover{background:#d3d3d3}table{width:100%}table tr:nth-child(2n-1){background:#1A1A1A}table td{padding:3px 4px}table td:nth-child(3):not([data-e=\"7\"]){width:20px;background:url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAACXBIWXMAAAsTAAALEwEAmpwYAAABFElEQVQ4je2Pu07DUBBEz/oGBAUPG3dpEEI0CApEjSIlvIrwP6Hj9TN8QmxACKhIgeySHtFgRAMKvvZSxJFIcIoISqZZaWdnZ0YoQRr4NSFvIWwUq47mejqx83o3fCs/xKF7Jkir4N6KOQtkAkemkZx8v3cGxd6eIIfAs8K+qSeuuU1c0CbwonCcBn6tLDUA2YUX29DTtL1QH+bspX9gQ09t6N2XVtCbOTfrmkQgNo1kvczABu4jIkvmY2pGmk/vAxXsp6wBqEg8MqIjEeCk093V/qoCoOdMZrmz3M+jV/OLpRUztOear2iHB9kkFQAbetfA1kjnMijtynayW1SQ6lhiQIRqL80v8f/g7x5oNK5QlQjgCxBXWhCbZi53AAAAAElFTkSuQmCC) right center no-repeat;background-width:16px}table td:nth-child(3)[data-e=\"7\"]{background:0 0}</style>";
 
 	const char HTTP_WIFI_SCAN[] PROGMEM   = "<tr><td onclick=\"c(this);\">{s}</td><td>{q} dBm</td><td data-e=\"{e}\"></td></tr>";
-	const char HTTP_WIFI_FORM[] PROGMEM   = "<div id=\"po\"><div id=\"m\"></div></div><div id=\"cnt\"><h1>WIFI CONNECTION</h1><table>{r}</table><br><br><label>SSID</label><input id=\"s\" name=\"s\" maxlength=50 placeholder=\"SSID\"><label>Password</label><input id=\"p\" name=\"p\" maxlength=64 placeholder=\"password\"><br><br><button class=\"btn\" onclick=\"ld('/wsa')\">Save</button></div>";
-
+	
+	#if WIFI_DHCP_ONLY == true
+		const char HTTP_WIFI_FORM[] PROGMEM   = "<div id=\"po\"><div id=\"m\"></div></div><div id=\"cnt\"><h1>WIFI CONNECTION</h1><table>{r}</table><br><br><label>SSID</label><input id=\"s\" name=\"s\" maxlength=50 placeholder=\"SSID\"><label>Password</label><input id=\"p\" name=\"p\" maxlength=64 placeholder=\"password\"><br><br><button class=\"btn\" onclick=\"ld('/wsa')\">Save</button></div>";
+	#else
+		const char HTTP_WIFI_FORM[] PROGMEM   = "<div id=\"po\"><div id=\"m\"></div></div><div id=\"cnt\"><h1>WIFI CONNECTION</h1><table>{r}</table><br><br><label>SSID</label><input id=\"s\" name=\"s\" maxlength=50 placeholder=\"SSID\"><label>Password</label><input id=\"p\" name=\"p\" maxlength=64 placeholder=\"password\"><label for=\"sip\">IP address</label><input type=\"text\" name=\"sip\"><label for=\"ssn\">Subnet</label><input type=\"text\" name=\"ssn\"><label for=\"sgw\">Gateway</label><input type=\"text\" name=\"sgw\"><label for=\"sds\">DNS server</label><input type=\"text\" name=\"sds\"><br><br><button class=\"btn\" onclick=\"ld('/wsa')\">Save</button></div>";
+	#endif
+	
 	const char HTTP_APP_INFO[] PROGMEM    = "{\"l\":\"{l}\", \"v\":\"{v}\", \"n\":\"{n}\", \"m\":\"{m}\", \"t\":\"{t}\"}";
 
 	#if defined  ESP8266 && HTTPS_8266_TYPE == FNGPRINT
-		const char HTTP_DEV_INFO[] PROGMEM = "{\"s1\":\"{s1}\", \"s2\":\"{s2}\", \"s3\":\"{s3}\", \"cid\":\"{cid}\", \"fid\":\"{fid}\", \"fss\":\"{fss}\", \"ss\":\"{ss}\", \"fs\":\"{fs}\", \"ab\":\"{ab}\", \"ac\":\"{ac}\", \"mc\":\"{mc}\", \"xf\":\"{xf}\", \"f\":\"{f}\"}";
+		const char HTTP_DEV_INFO[] PROGMEM = "{\"cid\":\"{cid}\", \"fid\":\"{fid}\", \"fss\":\"{fss}\", \"ss\":\"{ss}\", \"fs\":\"{fs}\", \"ab\":\"{ab}\", \"ac\":\"{ac}\", \"mc\":\"{mc}\", \"xf\":\"{xf}\", \"f\":\"{f}\"}";
 	#else
-		const char HTTP_DEV_INFO[] PROGMEM = "{\"s1\":\"{s1}\", \"s2\":\"{s2}\", \"s3\":\"{s3}\", \"cid\":\"{cid}\", \"fid\":\"{fid}\", \"fss\":\"{fss}\", \"ss\":\"{ss}\", \"fs\":\"{fs}\", \"ab\":\"{ab}\", \"ac\":\"{ac}\", \"mc\":\"{mc}\", \"xf\":\"{xf}\"}";
+		const char HTTP_DEV_INFO[] PROGMEM = "{\"cid\":\"{cid}\", \"fid\":\"{fid}\", \"fss\":\"{fss}\", \"ss\":\"{ss}\", \"fs\":\"{fs}\", \"ab\":\"{ab}\", \"ac\":\"{ac}\", \"mc\":\"{mc}\", \"xf\":\"{xf}\"}";
 	#endif
 
 
@@ -137,26 +144,6 @@
 		int bootTimes;
 		char boardMode = 'N';                    // Normal operation or Configuration mode?
 		String statusMessage = "";
-
-		strConfig config = {
-			"",
-			"",
-			"",
-			{"","",""},
-			{"","",""},
-			"yourESP",
-			"",
-			#if defined  ESP8266 && HTTPS_8266_TYPE == FNGPRINT
-				HTTPS_FNGPRINT,
-			#endif
-			#if CFG_AUTHENTICATE == true
-				CFG_PASS,
-			#endif
-			#if NEXT_OTA == true
-				"00000000000000000000000000000000",
-			#endif
-			"CFG"  // Magic Bytes
-		};
 
 
 		// similar to the ModeButtonState but has some extra states
@@ -184,23 +171,24 @@
 		void preSetDeviceName(String deviceName);
 		void preSetAutoUpdate(bool automaticUpdate);
 		void preSetAutoConfig(bool automaticConfig);
-		void preSetWifi(String ssid, String password);
+		void preSetWifi(const char *ssid, const char *password);
 
-		void setCallHome(bool callHome) __attribute__((deprecated));// <----- deprecated left for compatibility. Remove with version 3.0.0
+		void setCallHome(bool callHome) __attribute__((deprecated));// <----- deprecated left for compatibility. This will be removed with version 3.0.0
 		void setCallHomeInterval(unsigned long interval);
 
-		void begin(const char ea);
+		void begin(const char ea) __attribute__((deprecated));// <----- deprecated left for compatibility. This will be removed with version 3.0.0
+		void begin();
 
 		void loop();
 
 
-		void writeConfig(bool wifiSave = false);
-		void readConfig();
+		void writeConfig(configStruct &config);
+		void readConfig(configStruct &config);
 		void espRestart(char mmode);
-		void eraseFlash(int eepFrom, int eepTo);
+		void eraseEEPROM(int eepFrom, int eepTo);
+		void eraseEEPROM(const char ea);
 
 		void WiFiSetupAndConnect();
-		bool WiFiConnectToAP(bool multi = true);
 		void WiFiDisconnect();
 		void setClock();
 		
@@ -209,6 +197,9 @@
 		bool espInstaller(Stream &streamPtr, firmwareStruct *firmwareStruct, UpdateClassVirt& devObj, int command = U_FLASH);
 		
 		void addField(char* &defaultVal, const char *fieldLabel, const int length, const char type = 'L');
+
+		
+		
 		void iasLog(String msg);
 		int dPinConv(String orgVal);
 
@@ -238,20 +229,11 @@
 		const char *_compDate;
 		const int _modeButton;							// which gpio is used for selecting modes
 		unsigned int _nrXF					= 0;		// nr of extra fields required in the config manager
-
+		unsigned int _nrXFlastAdd			= 0;		// nr of extra fields required in the config manager
 		bool _updateOnBoot					= true;		// update on boot? (end of begin();)
 		bool _automaticConfig				= true;		// automaticly go to config on boot if there is no wifi connection present
-
 		bool _setPreSet						= false;	// ;) have there been any preSets set?
-		bool _setDeviceName					= false;	// is the device name set?
-		bool _configReaded					= false;	// has the config already been read?
-		bool _writeConfig					= false;	// flag to notify the loop to write the config settings
-		
 		bool _connected						= false;	// wifi connection status bool
-		bool _tryToConn						= false;	// is the wifi connector busy? (trying to connect)
-		bool _connFail						= false;	// did the last connection attempt faile
-		bool _connChangeMode				= false;	// flag to notify the loop to change from AP to STA mode
-		
 		
 		bool _timeSet						= false;	// maby?<---------------
 		unsigned long _lastTimeSet			= 0;
@@ -262,8 +244,7 @@
 		unsigned long _debugEntry;
 		AppState      _appState;
 
-		eFields fieldStruct[MAXNUMEXTRAFIELDS];
-
+		
 		THandlerFunction _firstBootCallback;
 		THandlerFunction _noPressCallback;
 		THandlerFunction _shortPressCallback;
@@ -282,12 +263,12 @@
 			------ ------ ------ ------ ------ ------ FUNCTION DEFINITIONS ------ ------ ------ ------ ------ ------
 		*/
 
-		void firstBoot(const char ea);
+		void firstBoot();
 		void printBoardInfo();
-		void processField();
 
 
 		String strWifiScan();
+		String strWifiCred();
 		String strCertScan(String path = "");
 		String servHdlRoot();
 		String servHdlDevInfo();
@@ -295,7 +276,8 @@
 		#if defined  ESP8266 && HTTPS_8266_TYPE	== FNGPRINT
 			String servHdlFngPrintSave(String fngprint);
 		#endif
-		String servHdlWifiSave(String newSSID, String newPass, int apNr=0);
+		String servHdlWifiSave(const char* newSSID, const char* newPass, const int apNr=0);
+		String servHdlWifiSave(const char* newSSID, const char* newPass, String ip, String subnet, String gateway, String dnsserv);
 		String servHdlAppSave(AsyncWebServerRequest *request);
 		String servHdlactcodeSave(String actcode="");
 

--- a/src/config.h
+++ b/src/config.h
@@ -6,7 +6,6 @@
 	#define DEBUG_LVL					2			// Debug level: 0 - 3 | none - max
 	#define DEBUG_EEPROM_CONFIG			false
 	#define DEBUG_FREE_HEAP				false
-	
 	#define SERIAL_SPEED				115200
 	#define BOOTSTATISTICS				true
 		
@@ -18,15 +17,18 @@
 	#define CFG_PASS					"admin"		// initial authentication password. You edit & change this in config mode. | max 16 char
 	#define CFG_PAGE_INFO				true		// include the info page in Config mode
 	#define CFG_PAGE_IAS 				true  		// include the IAS page in Config mode
-	#define CFG_ANNOUNCE				true		// Announce to IAS on which ip this device is during Config mode. (unstable with HTTPS_8266_TYPE CERTIFICATE during Config due to not enough heap)
+	#define CFG_ANNOUNCE				true		// Announce to IAS on which ip this device is during Config mode.
 	
 
 	// Wifi defines
 	#define WIFI_SMARTCONFIG			false		// Set to true to enable smartconfig by smartphone app "ESP Smart Config" or "ESP8266 SmartConfig" | This will add (+/- 2%) of program storage space and +/- 1%) of dynamic memory
 	#define WIFI_MULTI					true		// false: only 1 ssid & pass will be used | true: 3 sets of ssid & pass will be used
+	#define WIFI_MULTI_MAX				3			// Max nr of addable WiFi AP's | If you go for more than 3 AP's make sure to change CFG_EEP_START_ADDR(line 94) & FIELD_EEP_START_ADDR(line 95)
 	#define WIFI_MULTI_FORCE_RECONN_ANY	false		// By default wifi multi will only try to reconnect to the last AP it was connectected to. Setting this to true will force your esp to connect to any of the available AP's from the list.
 	#define WIFI_CONN_MAX_RETRIES 		20			// sets the maximum number of retries when trying to connect to the wifi
 	#define WIFI_USE_MDNS 				true  		// include MDNS responder http://yourboard.local
+	#define WIFI_DHCP_ONLY				true		// true = DHCP only, false = 1 x Static ip address | WiFiMulti does not support STATIC ip addresses
+	#define WIFICONNECTOR_DEBUG 		false
 	
 	
 	// Internal clock
@@ -41,30 +43,30 @@
 	
 	// HTTPS defines
 	#define HTTPS         				true				// Use HTTPS for OTA updates
-	#define HTTPS_8266_TYPE				FNGPRINT			// FNGPRINT / CERTIFICATE | ESP32 only accepts certificates | SET to FNGPRINT for backwards compatibility with 2.0.X
-	#define HTTPS_CERT_STORAGE			ST_SPIFFS			// ST_SPIFFS / ST_PROGMEM
-	#define HTTPS_FNGPRINT				"34 6d 0a 26 f0 40 3a 0a 1b f1 ca 8e c8 0c f5 14 21 83 7c b1" // Initial fingerprint. You can edit & change this later in config mode.
+	#define HTTPS_8266_TYPE				FNGPRINT			// FNGPRINT / CERTIFICATE | ESP32 only accepts certificates | SET to FNGPRINT for backwards compatibility with 2.0.X (ESP8266)
+	#define HTTPS_CERT_STORAGE			ST_SPIFFS			// ST_SPIFFS / ST_PROGMEM | If you want to be able to update your certificates from config mode choose for ST_SPIFFS
+	#define HTTPS_FNGPRINT				"34 6d 0a 26 f0 40 3a 0a 1b f1 ca 8e c8 0c f5 14 21 83 7c b1" // Initial fingerprint(ESP8266). You can edit & change this later in config mode.
 	
 	
 	// OTA defines
 	#define OTA_HOST 					"iotappstory.com"   // OTA update host
 	#define OTA_UPD_FILE 				"/ota/updates.php" 	// file at host that handles 8266 updates
 	#define OTA_LOG_FILE 				"/ota/logs.php" 	// file at host that handles 8266 updates
-	#define OTA_LOCAL_UPDATE			false				// Update firmware by uploading a .bin file in config mode
+	#define OTA_LOCAL_UPDATE			false				// Update firmware by uploading a .bin file in config mode | Only when config is stored in SPIFFS. CFG_STORAGE (line 15)
 	#define OTA_UPD_CHECK_SPIFFS		true				// Do you want to OTA update SPIFFS? | true / false
-	#define OTA_UPD_CHECK_NEXTION		false				// Do you want to OTA update your Nextion display? | true / false
+	#define OTA_UPD_CHECK_NEXTION		true				// Do you want to OTA update your Nextion display? | true / false
 
-	
-	// Nextion display defines
 	#if defined  ESP8266
+		#define OTA_BUFFER				1024
 		#define NEXT_RES				5		// Nextion reset pin | Default 5 / D1 | Use this pin to control a transistor or relay to "hard" reset your display(power) after updates
 		#define NEXT_RX					14		// Nextion RX pin | Default 14 / D5
 		#define NEXT_TX					12		// Nextion TX pin | Default 12 / D6
-		#define NEXT_BAUD				115200	// Nextion baudrate | 115200 / 57600
+		#define NEXT_BAUD				38400	// Nextion baudrate | 115200 / 57600 / 38400 / 19200
 	#elif defined ESP32
+		#define OTA_BUFFER				2048
 		#define NEXT_RES				5		// Nextion reset pin | Default 5 / D1 | Use this pin to control a transistor or relay to "hard" reset your display(power) after updates
-		#define NEXT_RX					16		// Nextion RX pin | Default 14 / D5
-		#define NEXT_TX					17		// Nextion TX pin | Default 12 / D6
+		#define NEXT_RX					16		// Nextion RX pin | Default 16
+		#define NEXT_TX					17		// Nextion TX pin | Default 17
 		#define NEXT_BAUD				115200	// Nextion baudrate | 115200 / 57600
 	#endif
  
@@ -81,12 +83,18 @@
 		#define MAXNUMEXTRAFIELDS 		8
 	#endif
 	
+	// EEPROM start addresses
+	// This is setup to let wifi & config strucs grow / shrink without effecting config & added fields by leaving space beteen structs.
+	// For a tighter & dynamic EEPROM layout use the commented out formulas behind the static values.
+	#define WIFI_EEP_START_ADDR			0			
+	#define CFG_EEP_START_ADDR			500		// WIFI_EEP_START_ADDR + ((sizeof(WiFiCredStruct) * WIFI_MULTI_MAX) + 2)
+	#define FIELD_EEP_START_ADDR		720		// CFG_EEP_START_ADDR + sizeof(configStruct) + 2
+	
 	
 	/**
 		------ ------ ------ ------ ------ ------ internal DEFINES for library ------ ------ ------ ------ ------ ------ 
 	*/
 
-	
 	// length of config variables
 	#define STRUCT_CHAR_ARRAY_SIZE  	50
 	#define STRUCT_PASSWORD_SIZE		64		// Thankyou reibuehl
@@ -118,6 +126,25 @@
 	#define MAGICBYTES    				"CFG"
 	#define MAGICEEP      				"%"
 	
+	
+	#if WIFI_DHCP_ONLY == false && WIFI_MULTI == true
+		#undef WIFI_MULTI
+		#define WIFI_MULTI false
+	#endif
+
+	
+	#if WIFI_MULTI == false || WIFI_DHCP_ONLY == false
+		#define WIFIBEGIN(x,y) WiFi.begin(x,y)			// add single credential
+		#define WIFIBEGINDEBUG "WiFi.begin"
+		#define WIFIRUN WiFi.status()
+		#define WIFIRUNDEBUG "WiFi.status()"
+	#else
+		#define WIFIBEGIN(x,y) wifiMulti.addAP(x,y)		// add multiple credentials
+		#define WIFIBEGINDEBUG "wifiMulti.addAP"
+		#define WIFIRUN wifiMulti.run()
+		#define WIFIRUNDEBUG "wifiMulti.run()"
+	#endif
+
 	
 	
 	#if defined  ESP8266

--- a/src/espressif/WiFiConnector.cpp
+++ b/src/espressif/WiFiConnector.cpp
@@ -1,0 +1,391 @@
+#include "WiFiConnector.h"
+
+
+
+void WiFiConnector::getAPfromEEPROM(WiFiCredStruct &config, const int apNr){
+	
+	#if WIFICONNECTOR_DEBUG == true
+		Serial.print(F("WIFICONNECTOR_DEBUG\t| running getAPfromEEPROM("));
+		Serial.print(apNr);
+		Serial.println(F(")"));
+	#endif
+	
+	EEPROM.begin(EEPROM_SIZE);
+	
+	const int eepStartAddress = WIFI_EEP_START_ADDR + ((apNr-1) * sizeof(WiFiCredStruct));
+	const int magicBytesBegin = eepStartAddress + sizeof(WiFiCredStruct) - 4;
+	
+	
+	#if WIFICONNECTOR_DEBUG == true
+		Serial.print(F("WIFICONNECTOR_DEBUG\t| Searching for magicBytes("));
+		Serial.print(MAGICBYTES);
+		Serial.print(F(") at EEPROM address "));
+		Serial.println(magicBytesBegin);
+	#endif
+	
+	// check for magicBytes to confirm the config struct is stored in EEPROM
+	if(EEPROM.read(magicBytesBegin) == MAGICBYTES[0] && EEPROM.read(magicBytesBegin + 1) == MAGICBYTES[1] && EEPROM.read(magicBytesBegin + 2) == MAGICBYTES[2]){
+		EEPROM.get(eepStartAddress, config);
+	}
+	EEPROM.end();
+	
+	//Serial.print("WIFICONNECTOR_DEBUG\t| config.ip: ");
+	//Serial.println(config.ip);
+	
+	//return config;
+}
+
+
+
+const char* WiFiConnector::getSSIDfromEEPROM(const int apNr){
+	EEPROM.begin(EEPROM_SIZE);
+	WiFiCredStruct config;
+	getAPfromEEPROM(config, apNr);
+	
+	return config.ssid;
+}
+
+
+void WiFiConnector::addAPtoEEPROM(const char *ssid, const char *password, const int apNr){
+	if(apNr > 0){
+		_configCount = apNr - 1;
+	}
+	
+	#if WIFI_MULTI == false
+		if(_configCount >= 1){
+			#if WIFICONNECTOR_DEBUG == true
+				Serial.println(F("WIFICONNECTOR_DEBUG\t| Currently WIFI_MULTI is set to false. Which limits you to 1 AP. Ignoring ALL other config."));
+			#endif
+		}else{
+	#endif
+	
+	#if WIFICONNECTOR_DEBUG == true
+		Serial.print(F("\nWIFICONNECTOR_DEBUG\t| Running addAPtoEEPROM(\""));
+		Serial.print(ssid);
+		Serial.print(F("\", \""));
+		Serial.print(password);
+		Serial.println(F("\");"));
+	#endif
+	
+	WiFiCredStruct config;
+	
+	strncpy(config.ssid, ssid, STRUCT_CHAR_ARRAY_SIZE);
+	strncpy(config.password, password, STRUCT_PASSWORD_SIZE);
+	
+	config.dhcp		= true;
+	_configCount++;
+	this->WiFiCredStructToEEPROM(config, _configCount);
+	
+	
+	
+	#if WIFI_MULTI == false
+		}
+	#endif
+}
+
+
+#if WIFI_DHCP_ONLY == false
+void WiFiConnector::addAPtoEEPROM(const char *ssid, const char *password, IPAddress ip, IPAddress subnet, IPAddress gateway, IPAddress dnsserv){
+	#if WIFICONNECTOR_DEBUG == true
+		Serial.print(F("\nWIFICONNECTOR_DEBUG\t| Running addAPtoEEPROM(\""));
+		Serial.print(ssid);
+		Serial.print(F("\", \""));
+		Serial.print(password);
+		Serial.print(F("\", \""));
+		Serial.print(ip);
+		Serial.print(F("\", \""));
+		Serial.print(subnet);
+		Serial.print(F("\", \""));
+		Serial.print(gateway);
+		Serial.print(F("\", \""));
+		Serial.print(dnsserv);
+		Serial.println(F("\");"));
+		Serial.println(F("WIFICONNECTOR_DEBUG\t| Currently the wifiMulti library only supports DHCP. Ignoring ALL other config."));
+	#endif
+	
+	WiFiCredStruct config;
+
+	strncpy(config.ssid, ssid, STRUCT_CHAR_ARRAY_SIZE);
+	strncpy(config.password, password, STRUCT_PASSWORD_SIZE);
+	
+	config.dhcp		= false;
+	config.ip 		= ip;
+	config.subnet 	= subnet;
+	config.gateway 	= gateway;
+	config.dnsserv 	= dnsserv;
+	
+	this->WiFiCredStructToEEPROM(config, 1);
+}
+#endif
+
+
+
+void WiFiConnector::addAPtoEEPROM(const char *ssid, const char *password, String ip, String subnet, String gateway, String dnsserv){
+	this->addAPtoEEPROM(ssid, password, this->ipFromString(ip), this->ipFromString(subnet), this->ipFromString(gateway), this->ipFromString(dnsserv));
+}
+
+
+
+void WiFiConnector::addAndShiftAPinEEPROM(const char *ssid, const char *password){
+	// get current AP1
+	WiFiCredStruct ap1;
+	this->getAPfromEEPROM(ap1, 1);
+	
+	// is AP1 valid?
+	if(strcmp(ap1.magicBytes, MAGICBYTES) == 0){
+		
+		// get current AP2
+		WiFiCredStruct ap2;
+		this->getAPfromEEPROM(ap2, 2);
+
+		// is AP2 valid?
+		if(strcmp(ap2.magicBytes, MAGICBYTES) == 0){
+			
+			// move AP2 to position 3
+			this->WiFiCredStructToEEPROM(ap2, 3);
+			_configCount = 3;
+			
+		}else{
+			_configCount = 2;
+		}
+		
+		// move AP1 to position 2
+		this->WiFiCredStructToEEPROM(ap1, 2);
+	}
+	
+	// write AP1
+	this->addAPtoEEPROM(ssid, password, 1);
+}
+
+
+
+void WiFiConnector::WiFiCredStructToEEPROM(WiFiCredStruct config, const int apNr){
+	EEPROM.begin(EEPROM_SIZE);
+	
+	const int configSize = sizeof(config);
+	const int eepStartAddress = WIFI_EEP_START_ADDR + ((apNr-1) * configSize);
+	
+	EEPROM.put(eepStartAddress, config);
+	EEPROM.end();
+	
+	#if WIFICONNECTOR_DEBUG == true
+		Serial.print(F("WIFICONNECTOR_DEBUG\t| "));
+		Serial.print(config.magicBytes);
+		Serial.print(F(" | Written config nr"));
+		Serial.print(apNr);
+		Serial.print(F(" to EEPROM from "));
+		Serial.print(eepStartAddress);
+		Serial.print(F(" to "));
+		Serial.println(apNr * configSize);
+	#endif
+}
+
+
+
+
+/** 
+	Setup WiFi
+*/
+bool WiFiConnector::setup(){
+	#if WIFICONNECTOR_DEBUG == true
+		Serial.println(F("\nWIFICONNECTOR_DEBUG\t| Running setup();"));
+	#endif
+	
+	EEPROM.begin(EEPROM_SIZE);
+	
+	
+	// config Variable to store custom object read from EEPROM.
+	WiFiCredStruct config;
+	
+	// get credentials from eeprom
+	const int configSize = sizeof(WiFiCredStruct);
+	int nrOfCfgFound = 0;
+	
+	#if WIFICONNECTOR_DEBUG == true
+		Serial.println(F("WIFICONNECTOR_DEBUG\t| Loading config settings from EEPROM"));
+	
+		Serial.print(F("WIFICONNECTOR_DEBUG\t| configSize: "));
+		Serial.println(configSize);
+		Serial.print(F("WIFICONNECTOR_DEBUG\t| Total of "));
+		Serial.print(WIFI_MULTI_MAX);
+		Serial.print(F(" x configSize: "));
+		Serial.println(configSize * WIFI_MULTI_MAX);
+	#endif
+	
+	for(int i=0; i < WIFI_MULTI_MAX; i++){
+		const int eepStartAddress = WIFI_EEP_START_ADDR + (i * configSize);
+		
+		// check for magicBytes to confirm the config struct is stored in EEPROM
+		const int magicBytesBegin = eepStartAddress + configSize - 4;
+		
+		#if WIFICONNECTOR_DEBUG == true
+			Serial.print(F("WIFICONNECTOR_DEBUG\t| Searching for magicBytes("));
+			Serial.print(MAGICBYTES);
+			Serial.print(F(") at EEPROM address "));
+			Serial.println(magicBytesBegin);
+		#endif
+		
+		if(EEPROM.read(magicBytesBegin) == MAGICBYTES[0] && EEPROM.read(magicBytesBegin + 1) == MAGICBYTES[1] && EEPROM.read(magicBytesBegin + 2) == MAGICBYTES[2]){
+			nrOfCfgFound++;
+		
+	
+			#if WIFICONNECTOR_DEBUG == true
+				Serial.print(F("WIFICONNECTOR_DEBUG\t| Loaded config nr"));
+				Serial.print(i+1);
+
+				Serial.print(F(" from EEPROM from "));
+				Serial.print(eepStartAddress);
+				Serial.print(F(" to "));
+				Serial.println((i+1) * configSize);
+			#endif
+		
+
+			EEPROM.get(eepStartAddress, config);
+			
+			#if WIFICONNECTOR_DEBUG == true
+				Serial.print(F("WIFICONNECTOR_DEBUG\t| SSID\t\t: "));
+				Serial.println(config.ssid);
+				Serial.print(F("WIFICONNECTOR_DEBUG\t| Password\t: "));
+				Serial.println(config.password);
+			#endif
+		
+			// setup wifi credentials
+			#if WIFI_DHCP_ONLY != true
+				if(!config.dhcp){
+					
+					#if WIFICONNECTOR_DEBUG == true
+						Serial.println(F("WIFICONNECTOR_DEBUG\t| IP settings\t: Static"));
+						Serial.print(F("WIFICONNECTOR_DEBUG\t| IPAddress\t: "));
+						Serial.println(config.ip);
+						
+						Serial.print(F("WIFICONNECTOR_DEBUG\t| Subnet\t: "));
+						Serial.println(config.subnet);
+						
+						Serial.print(F("WIFICONNECTOR_DEBUG\t| Gateway\t: "));
+						Serial.println(config.gateway);
+						
+						Serial.print(F("WIFICONNECTOR_DEBUG\t| DNS server\t: "));
+						Serial.println(config.dnsserv);
+
+						Serial.print(F("WIFICONNECTOR_DEBUG\t| Running "));
+						Serial.print(F("WiFi.config(\""));
+						Serial.print(config.ip);
+						Serial.print(F("\", \""));
+						Serial.print(config.gateway);
+						Serial.print(F("\", \""));
+						Serial.print(config.subnet);
+						Serial.print(F("\", \""));
+						Serial.print(config.dnsserv);
+						Serial.println(F("\")"));
+					
+						if(!WiFi.config(config.ip, config.gateway, config.subnet, config.dnsserv)){
+							Serial.println(F("WIFICONNECTOR_DEBUG\t| Failed to configure static ip. Continuing in DHCP mode."));
+						}else{
+							i = 3;
+						}
+						
+					#else
+						if(WiFi.config(config.ip, config.gateway, config.subnet, config.dnsserv)){
+							i = 3;
+						}
+					#endif
+					
+					_static = true;
+				}
+			#endif
+			
+			
+			#if WIFICONNECTOR_DEBUG == true
+				Serial.print(F("WIFICONNECTOR_DEBUG\t| Running "));
+				Serial.print(WIFIBEGINDEBUG);
+				Serial.print(F("(\""));
+				Serial.print(config.ssid);
+				Serial.print(F("\", \""));
+				Serial.print(config.password);
+				Serial.println(F("\")"));
+			#endif
+			
+			// add single credential
+			WIFIBEGIN(config.ssid, config.password);
+		}
+	}
+	
+	if(nrOfCfgFound == 0){
+		#if WIFICONNECTOR_DEBUG == true
+			Serial.println(F("WIFICONNECTOR_DEBUG\t| Failed to find previous stored config in EEPROM. Run addAPtoEEPROM and try again."));
+		#endif
+		return false;
+	}
+	
+	return true;
+}
+
+
+
+/**
+	Connect to Wifi AP
+*/
+bool WiFiConnector::connectToAP(const char *waitChar){
+	
+	int retries = WIFI_CONN_MAX_RETRIES;
+
+	#if WIFICONNECTOR_DEBUG == true
+		Serial.print(F("WIFICONNECTOR_DEBUG\t| Running "));
+		Serial.println(WIFIRUNDEBUG);
+	#endif
+	while (WIFIRUN != WL_CONNECTED && retries-- > 0 ) {
+		delay(500);
+		if(waitChar){
+			Serial.print(waitChar);
+		}
+	}
+
+	
+	if(waitChar){
+		Serial.println("");
+	}
+
+	if(retries > 0){
+		_connected = true;
+		return true;
+	}else{
+		_connected = false;
+		return false;
+	}
+}
+
+
+
+/**
+	Dusconnect wifi
+*/
+bool WiFiConnector::connectLoop(const char *waitChar){
+	if(WiFi.status() == WL_NO_SSID_AVAIL){
+		_connected = false;
+		WiFi.disconnect(false);
+		delay(10);
+		
+		if(this->connectToAP(waitChar)){
+			return true;
+		}
+	}
+	return false;
+}
+
+
+
+/**
+	Disconnect wifi
+*/
+void WiFiConnector::disconnect(){
+	WiFi.disconnect();
+	_connected = false;
+}
+
+
+
+IPAddress WiFiConnector::ipFromString(String strIP){
+	IPAddress ip;
+	ip.fromString(strIP);
+	return ip;
+}

--- a/src/espressif/WiFiConnector.h
+++ b/src/espressif/WiFiConnector.h
@@ -1,0 +1,70 @@
+#ifndef WiFiConnector_h
+	#define WiFiConnector_h
+	
+	// INCLUDES
+	#include <IOTAppStory.h>
+	#include <EEPROM.h>
+	#ifdef ESP8266
+		#include <ESP8266WiFi.h>
+		#include <ESP8266WiFiMulti.h>
+	#elif defined ESP32
+		#include <WiFi.h>
+		#include <WiFiMulti.h>
+	#endif
+	
+	
+	struct WiFiCredStruct{
+		char ssid[STRUCT_CHAR_ARRAY_SIZE] = "";
+		char password[STRUCT_PASSWORD_SIZE] = "";
+		#if WIFI_DHCP_ONLY == true
+			bool dhcp = true;
+		#else
+			bool dhcp = false;
+			IPAddress ip;
+			IPAddress subnet;
+			IPAddress gateway;
+			IPAddress dnsserv;
+		#endif
+		
+		const char magicBytes[4] = MAGICBYTES;
+	};
+	
+	
+	class WiFiConnector{
+
+		public:
+		
+			//WiFiConnector();
+			void getAPfromEEPROM(WiFiCredStruct &config, const int apNr);
+			const char* getSSIDfromEEPROM(const int apNr);
+			
+			void addAPtoEEPROM(const char *ssid, const char *password, const int apNr = 0);
+			void addAPtoEEPROM(const char *ssid, const char *password, IPAddress ip, IPAddress subnet, IPAddress gateway, IPAddress dnsserv);
+			void addAPtoEEPROM(const char *ssid, const char *password, String ip, String subnet, String gateway, String dnsserv);
+			
+			void addAndShiftAPinEEPROM(const char *ssid, const char *password);
+			
+			bool setup();
+			bool connectToAP(const char *waitChar = nullptr);
+			bool connectLoop(const char *waitChar = nullptr);
+			void disconnect();
+			
+			IPAddress ipFromString(String strIP);
+		
+			#if WIFI_MULTI == true
+				#ifdef ESP32
+					WiFiMulti wifiMulti;
+				#elif defined ESP8266
+					ESP8266WiFiMulti wifiMulti;
+				#endif
+			#endif
+		
+		private:
+			void WiFiCredStructToEEPROM(WiFiCredStruct config, const int apNr = 0);
+			
+			bool _connected			= false;	// wifi connection status bool
+			bool _static			= false;
+			int _configCount		= 0;
+	};
+	
+#endif

--- a/src/espressif/configServer.h
+++ b/src/espressif/configServer.h
@@ -16,19 +16,23 @@
 		#endif
 		#include <ESPAsyncWebServer.h>					// https://github.com/me-no-dev/ESPAsyncWebServer
 		
-		#define TEMPLATE_PLACEHOLDER '`'
 		
-		struct strConfig;
+		struct configStruct;
 		class IOTAppStory;
 		
 		
 		class configServer {
 			public:
-				configServer(IOTAppStory &ias);
+				configServer(IOTAppStory &ias, configStruct &config);
 				void run();
 			private:
 				IOTAppStory* _ias;
+				configStruct* _config;
 				std::unique_ptr<AsyncWebServer> 	server;
+
+				bool _tryToConn			= false;		// is the wifi connector busy? (trying to connect)
+				bool _connFail			= false;		// did the last connection attempt faile
+				bool _connChangeMode	= false;		// flag to notify the loop to change from AP to STA mode
 				
 				void onUpload(AsyncWebServerRequest *request, String filename, size_t index, uint8_t *data, size_t len, bool final);
 				void hdlReturn(AsyncWebServerRequest *request, String retHtml, String type = "text/html");

--- a/src/espressif/esp32/callServer_WiFiClientSecure.cpp
+++ b/src/espressif/esp32/callServer_WiFiClientSecure.cpp
@@ -1,7 +1,7 @@
 #ifdef  ESP32
 	#include "callServer_WiFiClientSecure.h"
 	
-	callServer::callServer(strConfig &config, int command){
+	callServer::callServer(configStruct &config, int command){
 		_config = &config;
 		_command = command;
 	}
@@ -176,7 +176,7 @@
 			mode = F("spiffs");
 			md5 = ESP.getSketchMD5();
 		}
-		#if NEXT_OTA == true
+		#if OTA_UPD_CHECK_NEXTION == true
 			else if(_command == U_NEXTION){
 				mode = F("nextion");
 				md5 = _config->next_md5;

--- a/src/espressif/esp32/callServer_WiFiClientSecure.h
+++ b/src/espressif/esp32/callServer_WiFiClientSecure.h
@@ -56,14 +56,14 @@
 			"-----END CERTIFICATE-----\n";
 		#endif
 		
-		struct strConfig;
+		struct configStruct;
 		struct firmwareStruct;
 		
 		
 		class callServer{
 			
 			public:
-				callServer(strConfig &config, int command = U_FLASH);
+				callServer(configStruct &config, int command = U_FLASH);
 				Stream &getStream(firmwareStruct *firmwareStruct);
 				
 				bool get(const char* url, String args);
@@ -78,7 +78,7 @@
 				#endif
 				String *_statusMessage;
 				
-				strConfig* _config;
+				configStruct* _config;
 				int _command;
 				const char* _callHost		= OTA_HOST;         // ota update host | Set in config.h
 				const char* _callFile		= OTA_UPD_FILE; 	// file at host that handles esp updates

--- a/src/espressif/esp8266/callServer_WiFiClientSecure.cpp
+++ b/src/espressif/esp8266/callServer_WiFiClientSecure.cpp
@@ -1,7 +1,7 @@
 #ifdef ESP8266
 	#include "callServer_WiFiClientSecure.h"
 	
-	callServer::callServer(strConfig &config, int command){
+	callServer::callServer(configStruct &config, int command){
 		_config = &config;
 		_command = command;
 	}
@@ -199,7 +199,7 @@
 			mode = F("spiffs");
 			md5 = ESP.getSketchMD5();
 		}
-		#if NEXT_OTA == true
+		#if OTA_UPD_CHECK_NEXTION == true
 			else if(_command == U_NEXTION){
 				mode = F("nextion");
 				md5 = _config->next_md5;

--- a/src/espressif/esp8266/callServer_WiFiClientSecure.h
+++ b/src/espressif/esp8266/callServer_WiFiClientSecure.h
@@ -10,7 +10,7 @@
 			#include <time.h>
 		#endif
 
-		#if NEXT_OTA == true
+		#if OTA_UPD_CHECK_NEXTION == true
 			#define U_NEXTION 300
 		#endif
 		
@@ -55,14 +55,14 @@
 				"-----END CERTIFICATE-----\n";
 		#endif
 
-		struct strConfig;
+		struct configStruct;
 		struct firmwareStruct;
 		
 		
 		class callServer{
 			
 			public:
-				callServer(strConfig &config, int command = U_FLASH);
+				callServer(configStruct &config, int command = U_FLASH);
 				Stream &getStream(firmwareStruct *firmwareStruct);
 				
 				bool get(const char* url, String args);
@@ -81,7 +81,7 @@
 				#endif
 				String *_statusMessage;
 				
-				strConfig* _config;
+				configStruct* _config;
 				int _command;
 				const char* _callHost		= OTA_HOST;         // ota update host | Set in config.h
 				const char* _callFile		= OTA_UPD_FILE; 	// file at host that handles esp updates

--- a/src/espressif/updateNextion.h
+++ b/src/espressif/updateNextion.h
@@ -1,6 +1,7 @@
 #ifndef _UPDATENEXTION
 	#define _UPDATENEXTION
 	
+	#include "../config.h"
 	#include "UpdateClassVirt.h"
 	#include <ESPNexUpload.h>
 
@@ -17,7 +18,7 @@
 			
 			virtual void sm(String *statusMessage);
 			
-			ESPNexUpload nextion{115200};
+			ESPNexUpload nextion{NEXT_BAUD};
 
 		private:
 			String *_statusMessage;

--- a/src/includes.h
+++ b/src/includes.h
@@ -2,6 +2,7 @@
 	#include <rom/spi_flash.h>					// enable flash chip id from the SDK
 	#include <WiFi.h>
 	#include <WiFiMulti.h>
+	#include "espressif/WiFiConnector.h"
 	#include <ESPmDNS.h>
 
 	#include "espressif/esp32/boardInfo.h"
@@ -11,7 +12,7 @@
 	#include "espressif/UpdateClassVirt.h"
 	#include <Update.h>
 	#include "espressif/updateESP.h"
-	#if NEXT_OTA == true
+	#if OTA_UPD_CHECK_NEXTION == true
 		#include "espressif/updateNextion.h"
 	#endif
 	
@@ -25,6 +26,7 @@
 #ifdef  ESP8266
 	#include <ESP8266WiFi.h>
 	#include <ESP8266WiFiMulti.h>
+	#include "espressif/WiFiConnector.h"
 	#include <ESP8266mDNS.h>
 
 	#include "espressif/esp8266/boardInfo.h"
@@ -33,7 +35,7 @@
 	
 	#include "espressif/UpdateClassVirt.h"
 	#include "espressif/updateESP.h"
-	#if NEXT_OTA == true
+	#if OTA_UPD_CHECK_NEXTION == true
 		#include "espressif/updateNextion.h"
 	#endif
 	

--- a/src/serialFeedback_EN.h
+++ b/src/serialFeedback_EN.h
@@ -1,11 +1,11 @@
 	/**
 		------ ------ ------ ------ ------ ------ DEFINED SERIAL FEEDBACK ------ ------ ------ ------ ------ ------ 
 	*/
-	#define SER_ERASE_FULL					" Full erase of EEPROM"
-	#define SER_ERASE_PART					" Partial erase of EEPROM"
+	#define SER_ERASE_FULL					" (F)ull erase of EEPROM"
+	#define SER_ERASE_PART					" (P)artial erase of EEPROM"
 	#define SER_ERASE_PART_EXT				" Partial erase of EEPROM but leaving config settings"
-	#define SER_ERASE_NONE					" Leave EEPROM intact"
-	#define SER_ERASE_FLASH					" Erasing Flash...\n From %4d to %4d\n"
+	#define SER_ERASE_NONE					" (L)eave EEPROM intact"
+	#define SER_ERASE_FLASH					" Erasing EEPROM...\n From %4d to %4d\n"
 	
 	#define SER_CALLBACK_FIRST_BOOT			" Run first boot callback"
 	#define SER_START						" Start "
@@ -23,7 +23,7 @@
 	#define SER_CONFIG_MODE					"\n\n\n\n C O N F I G U R A T I O N   M O D E\n"
 	#define SER_CONFIG_AP_MODE				" AP mode. Connect to Wifi AP \"%s\"\n And open 192.168.4.1\n"
 	#define SER_CONFIG_STA_MODE				" STA mode. Open "
-	#define SER_CONFIG_STA_MODE_CHANGE		" Changed to STA mode."
+	#define SER_CONFIG_STA_MODE_CHANGE		" Changed to STA mode. Reconnect to: "
 	#define SER_CONFIG_EXIT					" Exit config"
 	#define SER_CONFIG_ENTER				" Entering in Configuration Mode"
 	
@@ -34,12 +34,12 @@
 	#define SER_CONN_NONE_GO_CFG			" Going into Configuration Mode\n"
 	#define SER_CONN_NONE_CONTINU			"\n Continu without WiFi\n"
 	#define SER_CONN_LOST_RECONN			" Connection lost! Reconnecting"
-	#define SER_CONNECTED					"\n WiFi connected\n"
+	#define SER_CONNECTED					" WiFi connected\n"
 	#define SER_SYNC_TIME_NTP				" Synchronising time with NTP server\n "
 	
 	
 	#define SER_DEV_MAC						" Device MAC: "
-	#define SER_DEV_IP						" Assigned IP Address: "
+	#define SER_DEV_IP						" IP Address: "
 	#define SER_DEV_MDNS					" MDNS responder started: http://"
 	#define SER_DEV_MDNS_INFO				"\n\n To use mDNS Install host software:\n - For Linux, install Avahi (http://avahi.org/)\n - For Windows, install Bonjour (https://commaster.net/content/how-resolve-multicast-dns-windows)\n - For Mac OSX and iOS support is built in through Bonjour already"
 	#define SER_DEV_MDNS_FAIL				" MDNS responder failed to start"
@@ -88,6 +88,7 @@
 	
 	#define SER_SERV_DEV_INFO				" Serving device info"
 	#define SER_SERV_WIFI_SCAN_RES			" Serving results of Wifiscan"
+	#define SER_SERV_WIFI_CRED				" Serving Wifi credentials"
 	#define SER_SERV_CERT_SCAN_RES			" Serving results of certificate scan"
 	#define SER_SERV_APP_SETTINGS			" Serving App Settings"
 	
@@ -99,4 +100,4 @@
 	#define SER_CONN_REC_CRED_DB3			"\n Connect with received credentials: %s - %s\n"
 	#define SER_CONN_REC_CRED_PROC			"\n Processing received credentials"
 	#define SER_CONN_ADDED_AP_CRED			"\n Added wifi credentials for AP%d\n"
-	#define SER_CONN_CRED_MISSING			"SSID or Password is missing"
+	#define SER_CONN_CRED_MISSING			" SSID or Password is missing"


### PR DESCRIPTION
**Free heap**
After inplementing BearSSL with certificates in a previous PR we were running out of heap on the ESP8266. In larger apps this could cause crashes during ota updates on boot. And when entering config mode(when sending logs to IAS with the local ip address).

To free heap I have rewritten the oldest parts of this library:
- config structs for storing device info & wifi creds
- the addFields functions and struct

Both are stored in EEPROM and used global vars / arrays during runtime for use in multiple other functions. This was not a problem when this library started as they contained very little. But as functionality was added during time they became quite a load. While only used during boot and not or rarely in the developed app.

As the original libary was built around these structs and functions, quite a lot of code & the boot sequence has changed. This rewrite frees up +/- 10% heap during boot and +/-2% ram for the whole library.

**WiFi**
As the wifi credentials(3 sets) were stored in the original config struct. This had to be rewritten and I took the opportunity to also address the following issues / wishes:
- Static ip options
- beter WiFiscan the first time a page is loaded
- refactor WiFi functionality into separate files
-  more durable EEPROM layout which lasts between library updates(changes).

**Other fixes**
- ESP32 fix SPIFFS bug that prevents storing certificates on a fresh device
- Fixed missing NEXT_BAUD define which Stabelizes Nextion updates on the ESP8266 by setting the correct speed.
- Made getChipId available for the ESP32