### PR TITLE
Added missing MDNS.update(); for ESP8266 devices

### DIFF
--- a/src/espressif/ConfigServer.cpp
+++ b/src/espressif/ConfigServer.cpp
@@ -356,6 +356,9 @@ void ConfigServer::run() {
         while(exitConfig == false) {
 
             yield();
+            #if defined  ESP8266
+                MDNS.update();
+            #endif
 
             if(this->_ias->_connected) {
                 //DEBUG_PRINTLN("Configserver connected loop part");


### PR DESCRIPTION
This "got lost" during previous refactoring.
mDNS resolution fails for IASBlink #140