### PR TITLE
Fix Dependency on ESPNexUpload

### DIFF
--- a/src/espressif/ConfigServer.cpp
+++ b/src/espressif/ConfigServer.cpp
@@ -356,6 +356,9 @@ void ConfigServer::run() {
         while(exitConfig == false) {
 
             yield();
+            #if defined  ESP8266
+                MDNS.update();
+            #endif
 
             if(this->_ias->_connected) {
                 //DEBUG_PRINTLN("Configserver connected loop part");

--- a/src/espressif/UpdateNextionClass.cpp
+++ b/src/espressif/UpdateNextionClass.cpp
@@ -1,89 +1,92 @@
-/*                          =======================
-============================   C/C++ SOURCE FILE   ============================
-                            =======================                       *//**
-  UpdateNextion.cpp
+#include "../config.h"
+#if OTA_UPD_CHECK_NEXTION == true
+	/*                          =======================
+	============================   C/C++ SOURCE FILE   ============================
+								=======================                       *//**
+	  UpdateNextion.cpp
 
-  Created by Onno Dirkzwager on 10.02.2019.
-  Copyright (c) 2019 IOTAppStory. All rights reserved.
+	  Created by Onno Dirkzwager on 10.02.2019.
+	  Copyright (c) 2019 IOTAppStory. All rights reserved.
 
-*///===========================================================================
+	*///===========================================================================
 
-/*---------------------------------------------------------------------------*/
-/*                                INCLUDES                                   */
-/*---------------------------------------------------------------------------*/
+	/*---------------------------------------------------------------------------*/
+	/*                                INCLUDES                                   */
+	/*---------------------------------------------------------------------------*/
 
-#include <Arduino.h>
-#include "UpdateNextionClass.h"
+	#include <Arduino.h>
+	#include "UpdateNextionClass.h"
 
-/*---------------------------------------------------------------------------*/
-/*                        DEFINITIONS AND MACROS                             */
-/*---------------------------------------------------------------------------*/
+	/*---------------------------------------------------------------------------*/
+	/*                        DEFINITIONS AND MACROS                             */
+	/*---------------------------------------------------------------------------*/
 
-/*---------------------------------------------------------------------------*/
-/*                        TYPEDEFS AND STRUCTURES                            */
-/*---------------------------------------------------------------------------*/
+	/*---------------------------------------------------------------------------*/
+	/*                        TYPEDEFS AND STRUCTURES                            */
+	/*---------------------------------------------------------------------------*/
 
-/*---------------------------------------------------------------------------*/
-/*                                PROTOTYPES                                 */
-/*---------------------------------------------------------------------------*/
+	/*---------------------------------------------------------------------------*/
+	/*                                PROTOTYPES                                 */
+	/*---------------------------------------------------------------------------*/
 
-/*---------------------------------------------------------------------------*/
-/*                            LOCAL VARIABLES                                */
-/*---------------------------------------------------------------------------*/
+	/*---------------------------------------------------------------------------*/
+	/*                            LOCAL VARIABLES                                */
+	/*---------------------------------------------------------------------------*/
 
-UpdateNextionClass UpdateNextion;
+	UpdateNextionClass UpdateNextion;
 
-/*---------------------------------------------------------------------------*/
-/*                        FUNCTION IMPLEMENTATION                            */
-/*---------------------------------------------------------------------------*/
+	/*---------------------------------------------------------------------------*/
+	/*                        FUNCTION IMPLEMENTATION                            */
+	/*---------------------------------------------------------------------------*/
 
-/*-----------------------------------------------------------------------------
-                        UpdateNextionClass prepareUpdate
+	/*-----------------------------------------------------------------------------
+							UpdateNextionClass prepareUpdate
 
-*///---------------------------------------------------------------------------
-bool UpdateNextionClass::prepareUpdate(uint32_t upd_size, String &upd_md5, uint16_t command) {
+	*///---------------------------------------------------------------------------
+	bool UpdateNextionClass::prepareUpdate(uint32_t upd_size, String &upd_md5, uint16_t command) {
 
-    // prepare upload: setup serial connection, send update command and send the expected update size
-    if(!this->nextion.prepareUpload(upd_size)) {
-        (*this->_statusMessage) = this->nextion.statusMessage;
-        return false;
-    }
+		// prepare upload: setup serial connection, send update command and send the expected update size
+		if(!this->nextion.prepareUpload(upd_size)) {
+			(*this->_statusMessage) = this->nextion.statusMessage;
+			return false;
+		}
 
-    return true;
-}
+		return true;
+	}
 
-/*-----------------------------------------------------------------------------
-                        UpdateNextionClass update
+	/*-----------------------------------------------------------------------------
+							UpdateNextionClass update
 
-*///---------------------------------------------------------------------------
-bool UpdateNextionClass::update(uint8_t *file_buf, size_t buf_size) {
+	*///---------------------------------------------------------------------------
+	bool UpdateNextionClass::update(uint8_t *file_buf, size_t buf_size) {
 
-    // Write the buffered bytes to the nextion display. If this fails, return false.
-    if(!this->nextion.upload(file_buf, buf_size)) {
-        (*this->_statusMessage) = this->nextion.statusMessage;
-        return false;
-    }
+		// Write the buffered bytes to the nextion display. If this fails, return false.
+		if(!this->nextion.upload(file_buf, buf_size)) {
+			(*this->_statusMessage) = this->nextion.statusMessage;
+			return false;
+		}
 
-    return true;
-}
+		return true;
+	}
 
-/*-----------------------------------------------------------------------------
-                        UpdateNextionClass end
+	/*-----------------------------------------------------------------------------
+							UpdateNextionClass end
 
-*///---------------------------------------------------------------------------
-bool UpdateNextionClass::end() {
-    // end: wait(delay) for the nextion to finish the update process, send nextion reset command and end the serial connection to the nextion
-    this->nextion.end();
-}
+	*///---------------------------------------------------------------------------
+	bool UpdateNextionClass::end() {
+		// end: wait(delay) for the nextion to finish the update process, send nextion reset command and end the serial connection to the nextion
+		this->nextion.end();
+	}
 
-/*-----------------------------------------------------------------------------
-                        UpdateNextionClass sm
+	/*-----------------------------------------------------------------------------
+							UpdateNextionClass sm
 
-*///---------------------------------------------------------------------------
-void UpdateNextionClass::sm(String *statusMessage) {
-    this->_statusMessage = statusMessage;
-}
+	*///---------------------------------------------------------------------------
+	void UpdateNextionClass::sm(String *statusMessage) {
+		this->_statusMessage = statusMessage;
+	}
 
-/*---------------------------------------------------------------------------*/
-/*                                    EOF                                    */
-/*---------------------------------------------------------------------------*/
+	/*---------------------------------------------------------------------------*/
+	/*                                    EOF                                    */
+	/*---------------------------------------------------------------------------*/
+#endif

--- a/src/espressif/UpdateNextionClass.h
+++ b/src/espressif/UpdateNextionClass.h
@@ -1,63 +1,66 @@
-/*                          =======================
-============================   C/C++ HEADER FILE   ============================
-                            =======================                       *//**
-  UpdateNextionClass.h
-
-  Created by Onno Dirkzwager on 10.02.2019.
-  Copyright (c) 2019 IOTAppStory. All rights reserved.
-
-*///===========================================================================
-
-#ifndef __UpdateNextionClass_h__
-#define __UpdateNextionClass_h__
-
-/*---------------------------------------------------------------------------*/
-/*                                    INCLUDES                               */
-/*---------------------------------------------------------------------------*/
-
 #include "../config.h"
-#include "UpdateClassVirt.h"
-#include <ESPNexUpload.h>
+#if OTA_UPD_CHECK_NEXTION == true
+	/*                          =======================
+	============================   C/C++ HEADER FILE   ============================
+								=======================                       *//**
+	  UpdateNextionClass.h
 
-/*---------------------------------------------------------------------------*/
-/*                            DEFINITIONS AND MACROS                         */
-/*---------------------------------------------------------------------------*/
+	  Created by Onno Dirkzwager on 10.02.2019.
+	  Copyright (c) 2019 IOTAppStory. All rights reserved.
 
-/*---------------------------------------------------------------------------*/
-/*                        TYPEDEFS, CLASSES AND STRUCTURES                   */
-/*---------------------------------------------------------------------------*/
+	*///===========================================================================
 
-/*                          =======================
-============================   CLASS DEFINITION    ============================
-                            =======================                       *//**
-  UpdateNextionClass.
+	#ifndef __UpdateNextionClass_h__
+		#define __UpdateNextionClass_h__
 
-*//*=========================================================================*/
-class UpdateNextionClass : public UpdateClassVirt {
-public:
-    ~UpdateNextionClass() {};
+		/*---------------------------------------------------------------------------*/
+		/*                                    INCLUDES                               */
+		/*---------------------------------------------------------------------------*/
 
-    virtual bool prepareUpdate(uint32_t upd_size, String &upd_md5, uint16_t command);
+		
+		#include "UpdateClassVirt.h"
+		#include <ESPNexUpload.h>
 
-    virtual bool update(uint8_t *file_buf, size_t buf_size);
+		/*---------------------------------------------------------------------------*/
+		/*                            DEFINITIONS AND MACROS                         */
+		/*---------------------------------------------------------------------------*/
 
-    virtual bool end(void);
+		/*---------------------------------------------------------------------------*/
+		/*                        TYPEDEFS, CLASSES AND STRUCTURES                   */
+		/*---------------------------------------------------------------------------*/
 
-    virtual void sm(String *statusMessage);
+		/*                          =======================
+		============================   CLASS DEFINITION    ============================
+									=======================                       *//**
+		  UpdateNextionClass.
 
-    ESPNexUpload nextion{NEXT_BAUD};
+		*//*=========================================================================*/
+		class UpdateNextionClass : public UpdateClassVirt {
+			public:
+				~UpdateNextionClass() {};
 
-private:
-    String* _statusMessage;
-};
+				virtual bool prepareUpdate(uint32_t upd_size, String &upd_md5, uint16_t command);
 
-/*---------------------------------------------------------------------------*/
-/*                                GLOBAL VARIABLES                           */
-/*---------------------------------------------------------------------------*/
+				virtual bool update(uint8_t *file_buf, size_t buf_size);
 
-extern UpdateNextionClass UpdateNextion;
+				virtual bool end(void);
 
-/*---------------------------------------------------------------------------*/
-/*                                    EOF                                    */
-/*---------------------------------------------------------------------------*/
-#endif // __UpdateNextionClass_h__
+				virtual void sm(String *statusMessage);
+
+				ESPNexUpload nextion{NEXT_BAUD};
+
+			private:
+				String* _statusMessage;
+		};
+
+		/*---------------------------------------------------------------------------*/
+		/*                                GLOBAL VARIABLES                           */
+		/*---------------------------------------------------------------------------*/
+
+		extern UpdateNextionClass UpdateNextion;
+
+		/*---------------------------------------------------------------------------*/
+		/*                                    EOF                                    */
+		/*---------------------------------------------------------------------------*/
+	#endif // __UpdateNextionClass_h__
+#endif


### PR DESCRIPTION
Wrapped the code into an precompiler if statement to prevent the compiler from checking the code when OTA_UPD_CHECK_NEXTION is false and the Nextion library is not included:

#include "../config.h"
#if OTA_UPD_CHECK_NEXTION == true
... code ...
#endif

This should fix the following issue: 2.1.0 Dependency on ESPNexUpload Library #129