### PR TITLE
Only connect to Wifi if there is NO connection

### DIFF
--- a/src/IOTAppStory.cpp
+++ b/src/IOTAppStory.cpp
@@ -258,7 +258,11 @@ void IOTAppStory::begin() {
 
         // --------- START WIFI --------------------------
         // Setup wifi with cred etc connect to AP
-        this->WiFiSetupAndConnect();
+	// Only connect if not *already* connected from some action before the IOTAppStory::begin() call.
+	// This helps avoids wifi managers interfering with each other - it's a quick hack but *seems* to work just fine.
+        if(!this->_connected) {
+	    this->WiFiSetupAndConnect();
+        }
 
         // Synchronize time useing SNTP. This is necessary to verify that
         // the TLS certificates offered by servers are currently valid.


### PR DESCRIPTION
I have notice an issue when calling IOTAppStory::begin() when wifi is already configured on an ESP32. The connection is disconnected and IAS attempts to connect using its own internal routines. This can be annoying and interfere with the authors intent, By only calling when there is no connection, this can be avoided, without and greater impact to the library functionality.

##TLDR
Only connect if not *already* connected from some action before the IOTAppStory::begin() call. This helps avoids wifi managers interfering with each other - it's a quick hack but *seems* to work just fine.