### PR TITLE
Added & updated callbacks

### DIFF
--- a/src/IOTAppStory.cpp
+++ b/src/IOTAppStory.cpp
@@ -699,6 +699,9 @@ bool IOTAppStory::iotUpdater(int command) {
         #if DEBUG_LVL >= 2
             DEBUG_PRINTLN(" " + this->statusMessage);
         #endif
+        if(this->_firmwareNoUpdateCallback) {
+            this->_firmwareNoUpdateCallback(this->statusMessage);
+        }
 
         return false;
     }
@@ -835,7 +838,7 @@ bool IOTAppStory::espInstaller(Stream &streamPtr, FirmwareStruct *firmwareStruct
                     DEBUG_PRINTLN(" " + this->statusMessage);
                 #endif
                 if(this->_firmwareUpdateErrorCallback) {
-                    this->_firmwareUpdateErrorCallback();
+                    this->_firmwareUpdateErrorCallback(this->statusMessage);
                 }
             }
         }
@@ -1404,6 +1407,14 @@ void IOTAppStory::onFirmwareUpdateCheck(THandlerFunction value) {
 }
 
 /*-----------------------------------------------------------------------------
+                        IOTAppStory onFirmwareNoUpdate
+
+*///---------------------------------------------------------------------------
+void IOTAppStory::onFirmwareNoUpdate(THandlerFunctionStr value) {
+    this->_firmwareNoUpdateCallback = value;
+}
+
+/*-----------------------------------------------------------------------------
                         IOTAppStory onFirmwareUpdateDownload
 
 *///---------------------------------------------------------------------------
@@ -1423,7 +1434,7 @@ void IOTAppStory::onFirmwareUpdateProgress(THandlerFunctionArg value) {
                         IOTAppStory onFirmwareUpdateError
 
 *///---------------------------------------------------------------------------
-void IOTAppStory::onFirmwareUpdateError(THandlerFunction value) {
+void IOTAppStory::onFirmwareUpdateError(THandlerFunctionStr value) {
     this->_firmwareUpdateErrorCallback = value;
 }
 

--- a/src/IOTAppStory.h
+++ b/src/IOTAppStory.h
@@ -137,6 +137,7 @@ enum AppState {
 // callback template definition
 typedef std::function<void(void)> THandlerFunction;
 typedef std::function<void(int, int)> THandlerFunctionArg;
+typedef std::function<void(String)> THandlerFunctionStr;
 
 /*                          =======================
 ============================   CLASS DEFINITION    ============================
@@ -207,9 +208,13 @@ public:
     void onModeButtonVeryLongPress(THandlerFunction fn);    // called when state is changed to very long press
     void onConfigMode(THandlerFunction fn);                 // called when the app is about to enter in configuration mode
     void onFirmwareUpdateCheck(THandlerFunction fn);        // called when the app checks for firmware updates
+    void onFirmwareNoUpdate(THandlerFunctionStr fn);        // called when no updates are available. 
+                                                            // This could have multiple reasons: not necessary, not selected, no file, unknown device or account, not compatible etc.
+                                                            // this callback returns a var String statusMessage
     void onFirmwareUpdateDownload(THandlerFunction fn);     // called when firmware download starts
     void onFirmwareUpdateProgress(THandlerFunctionArg fn);  // called during update process
-    void onFirmwareUpdateError(THandlerFunction fn);        // called when firmware update ends in an error
+    void onFirmwareUpdateError(THandlerFunctionStr fn);     // called when firmware update ends in an error 
+                                                            // this callback returns a var String statusMessage
     void onFirmwareUpdateSuccess(THandlerFunction fn);      // called when firmware update ends in success
 
 
@@ -259,9 +264,10 @@ private:
     THandlerFunction _veryLongPressCallback;
     THandlerFunction _configModeCallback;
     THandlerFunction _firmwareUpdateCheckCallback;
+    THandlerFunctionStr _firmwareNoUpdateCallback;
     THandlerFunction _firmwareUpdateDownloadCallback;
     THandlerFunctionArg _firmwareUpdateProgressCallback;
-    THandlerFunction _firmwareUpdateErrorCallback;
+    THandlerFunctionStr _firmwareUpdateErrorCallback;
     THandlerFunction _firmwareUpdateSuccessCallback;
 
     /**


### PR DESCRIPTION
**Added** 
onFirmwareNoUpdate(String statusMessage) callback
Called when no updates are available. This could have multiple reasons: not necessary, not selected, no file, unknown device or account, not compatible etc. This callback returns a var String statusMessage.

**Updated**
Changed onFirmwareUpdateError() to onFirmwareUpdateError(String statusMessage)
To return a String statusMessage.