### PR TITLE
Added missing String statusMessage in callbacks

### DIFF
--- a/examples/LOLIN(WEMOS) D1 mini/Wemos-IASLoader/Wemos-IASLoader.ino
+++ b/examples/LOLIN(WEMOS) D1 mini/Wemos-IASLoader/Wemos-IASLoader.ino
@@ -114,7 +114,7 @@ void setup() {
     Serial.print(".");
   });
 
-  IAS.onFirmwareUpdateError([]() {
+  IAS.onFirmwareUpdateError([](String statusMessage) {
     dispTemplate_threeLineV1(F("Update"), F("Error"), F("Check logs"));
   });
 

--- a/examples/LOLIN(WEMOS) D1 mini/Wemos-Shield-Clock/Wemos-Shield-Clock.ino
+++ b/examples/LOLIN(WEMOS) D1 mini/Wemos-Shield-Clock/Wemos-Shield-Clock.ino
@@ -124,7 +124,7 @@ void setup() {
     Serial.print(".");
   });
 
-  IAS.onFirmwareUpdateError([]() {
+  IAS.onFirmwareUpdateError([](String statusMessage) {
     dispTemplate_threeLineV1(F("Update"), F("Error"), F("Check logs"));
   });
   /*

--- a/examples/LOLIN(WEMOS) D1 mini/Wemos-Shield-DHT/Wemos-Shield-DHT.ino
+++ b/examples/LOLIN(WEMOS) D1 mini/Wemos-Shield-DHT/Wemos-Shield-DHT.ino
@@ -141,7 +141,7 @@ void setup() {
     Serial.print(".");
   });
 
-  IAS.onFirmwareUpdateError([]() {
+  IAS.onFirmwareUpdateError([](String statusMessage) {
     dispTemplate_threeLineV1(F("Update"), F("Error"), F("Check logs"));
   });
   /*

--- a/examples/LOLIN(WEMOS) D1 mini/Wemos-VirginSoil-OLED-Callbacks/Wemos-VirginSoil-OLED-Callbacks.ino
+++ b/examples/LOLIN(WEMOS) D1 mini/Wemos-VirginSoil-OLED-Callbacks/Wemos-VirginSoil-OLED-Callbacks.ino
@@ -99,7 +99,7 @@ void setup() {
     Serial.print(".");
   });
 
-  IAS.onFirmwareUpdateError([]() {
+  IAS.onFirmwareUpdateError([](String statusMessage) {
     dispTemplate_threeLineV1(F("Update"), F("Error"), F("Check logs"));
   });
   /*

--- a/examples/VirginSoil-Full/VirginSoil-Full.ino
+++ b/examples/VirginSoil-Full/VirginSoil-Full.ino
@@ -140,7 +140,7 @@ void setup() {
     Serial.println(F("*-------------------------------------------------------------------------*"));
   });
 
-  IAS.onFirmwareUpdateError([]() {
+  IAS.onFirmwareUpdateError([](String statusMessage) {
     Serial.println(F(" Update failed...Check your logs"));
     Serial.println(F("*-------------------------------------------------------------------------*"));
   });

--- a/examples/VirginSoil-NeoPixel-Callbacks/VirginSoil-NeoPixel-Callbacks.ino
+++ b/examples/VirginSoil-NeoPixel-Callbacks/VirginSoil-NeoPixel-Callbacks.ino
@@ -125,7 +125,7 @@ void setup() {
     delay(100);
   });
 
-  IAS.onFirmwareUpdateError([]() {
+  IAS.onFirmwareUpdateError([](String statusMessage) {
     pixels.clear();
     pixels.setPixelColor(0, red);                         // send red / update error to the neopixel
     pixels.show();


### PR DESCRIPTION
Updated the examples using the IAS.onFirmwareUpdateError([](String statusMessage) callback. Which was missing the String statusMessage var added in previous RC